### PR TITLE
商品一覧機能の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index]
  
   def index
-    # @items = Item.all
+    @items = Item.includes(:user).order("created_at DESC")
   end
 
   def new

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -15,7 +15,7 @@ class Item < ApplicationRecord
     validates :product_name
     validates :description_of_item
     validates :price ,format: { with:VALID_PRICEL_HALF}, numericality:{only_integer: true,
-    greater_than: 300, less_than: 9999999}
+    greater_than: 299, less_than: 9999999}
     validates :image
   end
 

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -125,26 +125,27 @@
     <h2 class='title'>ピックアップカテゴリー</h2>
     <%= link_to '新規投稿商品',new_item_path, class: "subtitle" %>
     <ul class='item-lists'>
-
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-      <li class='list'>
+      <% @items.each do |item| %>
+       
+        <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+        <li class='list'>
         <%= link_to "#" do %>
         <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
-
+          <%= image_tag item.image,class: "item-img" %>
           <%# 商品が売れていればsold outを表示しましょう %>
-          <div class='sold-out'>
+        <%# <% if current_user_id.transaction? %><%# ここは購入画面実装後に!!! %>
+          <%# <div class='sold-out'>
             <span>Sold Out!!</span>
-          </div>
+          </div> %>
+        <%# <% end %> 
           <%# //商品が売れていればsold outを表示しましょう %>
-
         </div>
         <div class='item-info'>
           <h3 class='item-name'>
-            <%= "商品名" %>
+            <%= item.product_name %>
           </h3>
           <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
+            <span><%= item.price %>円<br><%= item.product_status.name%></span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>
@@ -152,30 +153,9 @@
           </div>
         </div>
         <% end %>
-      </li>
+      <%end%>
+   </li>
       <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-
-      <%# 商品がない場合のダミー %>
-      <%# 商品がある場合は表示されないようにしましょう %>
-      <li class='list'>
-        <%= link_to '#' do %>
-        <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            商品を出品してね！
-          </h3>
-          <div class='item-price'>
-            <span>99999999円<br>(税込み)</span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
-            </div>
-          </div>
-        </div>
-        <% end %>
-      </li>
-      <%# //商品がある場合は表示されないようにしましょう %>
-      <%# /商品がない場合のダミー %>
     </ul>
   </div>
   <%# /商品一覧 %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -159,7 +159,28 @@
     </ul>
   </div>
   <%# /商品一覧 %>
-</div>
+        <%# 商品がない場合のダミー %>
+      <%# 商品がある場合は表示されないようにしましょう %>
+    <% if @item = nil  %> 
+      <li class='list'>
+        <%= link_to '#' do %>
+        <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>
+        <div class='item-info'>
+          <h3 class='item-name'>
+            商品を出品してね！
+          </h3>
+          <div class='item-price'>
+            <span>99999999円<br>(税込み)</span>
+            <div class='star-btn'>
+              <%= image_tag "star.png", class:"star-icon" %>
+              <span class='star-count'>0</span>
+            </div>
+          </div>
+        </div>
+        <% end %> 
+      </li>
+     </div>
+  <% end %>
 <div class='purchase-btn'>
   <span class='purchase-btn-text'>出品する</span>
   <a href="#">

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -161,7 +161,7 @@
   <%# /商品一覧 %>
         <%# 商品がない場合のダミー %>
       <%# 商品がある場合は表示されないようにしましょう %>
-    <% if @item = nil  %> 
+    <% if @items.length == 0 %> 
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>


### PR DESCRIPTION
#What
商品一覧させる機能の実装

#Why
出品された商品の一覧を掲載させる為

【実装条件一覧】
・画像が表示されており、画像がリンク切れなどになっていないこと
・「画像/価格/商品名」の3つの情報について表示できていること
・ログアウト状態のユーザーでも、商品一覧表示ページを見ることができること
https://gyazo.com/637de178218ebc6c37bbde9236a75d2a


・出品した商品の一覧表示ができていること
・上から、出品された日時が新しい順に表示されること
https://gyazo.com/ada7b9993a3dcc1b156f6a644821e8d4

・売却済みの商品は、画像上に「sold out」の文字が表示されるようになっていること
※こちらは購入画面実装後に購入画面の中のidカラムと条件分岐させる。
